### PR TITLE
added terraform configuration files for cluster deployment

### DIFF
--- a/terraform/iaas-cluster-deployment-tf/aws/cluster/cluster.tf
+++ b/terraform/iaas-cluster-deployment-tf/aws/cluster/cluster.tf
@@ -1,0 +1,40 @@
+data "spectrocloud_cloudaccount_aws" "account" {
+  name = var.aws-cloud-account-name
+}
+
+data "spectrocloud_cluster_profile" "profile" {
+  name = var.cluster_profile
+}
+
+resource "spectrocloud_cluster_aws" "cluster" {
+  name             = "aws-cluster"
+  tags             = ["aws", "tutorial"]
+  cloud_account_id = data.spectrocloud_cloudaccount_aws.account.id
+
+  cloud_config {
+    region        = var.region
+    ssh_key_name  = var.aws_ssh_key_name
+  }
+
+  cluster_profile {
+    id = data.spectrocloud_cluster_profile.profile.id
+  }
+
+  machine_pool {
+    control_plane           = true
+    control_plane_as_worker = true
+    name                    = "master-pool"
+    count                   = var.master_nodes.count
+    instance_type           = var.master_nodes.instance_type
+    disk_size_gb            = var.master_nodes.disk_size_gb
+    azs                     = var.master_nodes.availability_zones
+  }
+
+  machine_pool {
+    name          = "worker-basic"
+    count         = var.worker_nodes.count
+    instance_type = var.worker_nodes.instance_type
+    disk_size_gb  = var.worker_nodes.disk_size_gb
+    azs           = var.worker_nodes.availability_zones
+  }
+}

--- a/terraform/iaas-cluster-deployment-tf/aws/cluster/manifest.yaml
+++ b/terraform/iaas-cluster-deployment-tf/aws/cluster/manifest.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-universe-service
+spec:
+  type: LoadBalancer
+  selector:
+    app: hello-universe
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-universe-deployment
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: hello-universe
+  template:
+    metadata:
+      labels:
+        app: hello-universe
+    spec:
+      containers:
+      - name: hello-universe
+        image: ghcr.io/spectrocloud/hello-universe:1.0.10
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080

--- a/terraform/iaas-cluster-deployment-tf/aws/cluster/provider.tf
+++ b/terraform/iaas-cluster-deployment-tf/aws/cluster/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.11.1"
+      source  = "spectrocloud/spectrocloud"
+    }
+  }
+}
+
+provider "spectrocloud" {
+  project_name = "Default"
+  api_key = var.spectrocloud_api_key
+}

--- a/terraform/iaas-cluster-deployment-tf/aws/cluster/terraform.tfvars
+++ b/terraform/iaas-cluster-deployment-tf/aws/cluster/terraform.tfvars
@@ -1,0 +1,19 @@
+spectrocloud_api_key    = "j54AsdjnSP2YU9jJF1K5dVYeURWzO4qd"
+aws_ssh_key_name        = "palette-key"
+aws-cloud-account-name  = "aws-palette"
+cluster_profile         = "tf-aws-profile"
+region                  = "us-east-1"
+
+master_nodes = {
+    count           = "1"
+    instance_type   = "m5.large"
+    disk_size_gb    = "50"
+    availability_zones = ["us-east-1a"]
+}
+
+worker_nodes = {
+    count           = "1"
+    instance_type   = "m5.large"
+    disk_size_gb    = "50"
+    availability_zones = ["us-east-1a"]
+} 

--- a/terraform/iaas-cluster-deployment-tf/aws/cluster/variables.tf
+++ b/terraform/iaas-cluster-deployment-tf/aws/cluster/variables.tf
@@ -1,0 +1,29 @@
+variable "spectrocloud_api_key" {}
+variable "cluster_profile" {}
+variable "region" {}
+variable "aws_ssh_key_name" {}
+
+variable "aws-cloud-account-name" {
+    type = string
+    description = "The name of your AWS account as assigned in Palette"
+}
+
+variable "master_nodes" {
+    type = object({
+        count           = string
+        instance_type   = string
+        disk_size_gb    = string
+        availability_zones = list(string)
+    })
+    description = "Master nodes configuration."
+}
+
+variable "worker_nodes" {
+    type = object({
+        count           = string
+        instance_type   = string
+        disk_size_gb    = string
+        availability_zones = list(string)
+    })
+    description = "Worker nodes configuration."
+}

--- a/terraform/iaas-cluster-deployment-tf/aws/profile/cluster_profile.tf
+++ b/terraform/iaas-cluster-deployment-tf/aws/profile/cluster_profile.tf
@@ -1,0 +1,51 @@
+resource "spectrocloud_cluster_profile" "profile" {
+  name  = "tf-aws-profile"
+  tags  = ["aws", "tutorial"]
+  cloud = "aws"
+  type  = "cluster"
+
+  pack {
+    name   = data.spectrocloud_pack.ubuntu.name
+    tag    = data.spectrocloud_pack.ubuntu.version
+    uid    = data.spectrocloud_pack.ubuntu.id
+    values = data.spectrocloud_pack.ubuntu.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.k8s.name
+    tag    = data.spectrocloud_pack.k8s.version
+    uid    = data.spectrocloud_pack.k8s.id
+    values = data.spectrocloud_pack.k8s.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.cni.name
+    tag    = data.spectrocloud_pack.cni.version
+    uid    = data.spectrocloud_pack.cni.id
+    values = data.spectrocloud_pack.cni.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.csi.name
+    tag    = data.spectrocloud_pack.csi.version
+    uid    = data.spectrocloud_pack.csi.id
+    values = data.spectrocloud_pack.csi.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.proxy.name
+    tag    = data.spectrocloud_pack.proxy.version
+    uid    = data.spectrocloud_pack.proxy.id
+    values = data.spectrocloud_pack.proxy.values
+  }
+
+  pack {
+    name = "hello-universe"
+    type = "manifest"
+    tag  = "1.0.0"
+    manifest {
+      name    = "hello-universe"
+      content = file("manifest.yaml")
+    }
+  }
+}

--- a/terraform/iaas-cluster-deployment-tf/aws/profile/data.tf
+++ b/terraform/iaas-cluster-deployment-tf/aws/profile/data.tf
@@ -1,0 +1,24 @@
+data "spectrocloud_pack" "csi" {
+  name    = "csi-aws"
+  version = "1.0.0"
+}
+
+data "spectrocloud_pack" "cni" {
+  name    = "cni-calico"
+  version = "3.24.5"
+}
+
+data "spectrocloud_pack" "k8s" {
+  name    = "kubernetes"
+  version = "1.21.14"
+}
+
+data "spectrocloud_pack" "ubuntu" {
+  name    = "ubuntu-aws"
+  version = "20.04"
+}
+
+data "spectrocloud_pack" "proxy" {
+  name = "spectro-proxy"
+  version  = "1.2.0"
+}

--- a/terraform/iaas-cluster-deployment-tf/aws/profile/manifest.yaml
+++ b/terraform/iaas-cluster-deployment-tf/aws/profile/manifest.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-universe-service
+spec:
+  type: LoadBalancer
+  selector:
+    app: hello-universe
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-universe-deployment
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: hello-universe
+  template:
+    metadata:
+      labels:
+        app: hello-universe
+    spec:
+      containers:
+      - name: hello-universe
+        image: ghcr.io/spectrocloud/hello-universe:1.0.10
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080

--- a/terraform/iaas-cluster-deployment-tf/aws/profile/provider.tf
+++ b/terraform/iaas-cluster-deployment-tf/aws/profile/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.11.1"
+      source  = "spectrocloud/spectrocloud"
+    }
+  }
+}
+
+provider "spectrocloud" {
+  project_name = "Default"
+  api_key      = var.spectrocloud_api_key
+}

--- a/terraform/iaas-cluster-deployment-tf/aws/profile/terraform.tfvars
+++ b/terraform/iaas-cluster-deployment-tf/aws/profile/terraform.tfvars
@@ -1,0 +1,1 @@
+spectrocloud_api_key    =   "j54AsdjnSP2YU9jJF1K5dVYeURWzO4qd"

--- a/terraform/iaas-cluster-deployment-tf/aws/profile/variables.tf
+++ b/terraform/iaas-cluster-deployment-tf/aws/profile/variables.tf
@@ -1,0 +1,1 @@
+variable "spectrocloud_api_key" {}

--- a/terraform/iaas-cluster-deployment-tf/azure/cluster/provider.tf
+++ b/terraform/iaas-cluster-deployment-tf/azure/cluster/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.11.1"
+      source  = "spectrocloud/spectrocloud"
+    }
+  }
+}
+
+provider "spectrocloud" {
+  project_name = "Default"
+  api_key = var.spectrocloud_api_key
+}

--- a/terraform/iaas-cluster-deployment-tf/azure/cluster/resource.tf
+++ b/terraform/iaas-cluster-deployment-tf/azure/cluster/resource.tf
@@ -1,0 +1,46 @@
+data "spectrocloud_cloudaccount_azure" "account" {
+  name = var.azure-cloud-account-name
+}
+
+data "spectrocloud_cluster_profile" "profile" {
+  name = var.cluster_profile
+}
+
+resource "spectrocloud_cluster_azure" "cluster" {
+  name             = "azure-cluster"
+  tags             = ["ms-azure", "tutorial"]
+  cloud_account_id = data.spectrocloud_cloudaccount_azure.account.id
+
+  cloud_config {
+    subscription_id = var.subscription_id
+    resource_group  = var.resource_group
+    region          = var.region
+    ssh_key         = var.cluster_ssh_public_key
+  }
+
+  cluster_profile {
+    id = data.spectrocloud_cluster_profile.profile.id
+  }
+
+  machine_pool {
+    control_plane           = true
+    control_plane_as_worker = true
+    name                    = "master-pool"
+    count                   = var.master_nodes.count
+    instance_type           = var.master_nodes.instance_type
+    azs                     = var.master_nodes.availability_zones
+    is_system_node_pool     = var.master_nodes.is_system_node_pool
+    disk {
+      size_gb = var.master_nodes.disk_size_gb
+      type    = "Standard_LRS"
+    }
+  }
+
+  machine_pool {
+    name                 = "worker-basic"
+    count                = var.worker_nodes.count
+    instance_type        = var.worker_nodes.instance_type
+    azs                  = var.worker_nodes.availability_zones
+    is_system_node_pool  = var.worker_nodes.is_system_node_pool
+  }
+}

--- a/terraform/iaas-cluster-deployment-tf/azure/cluster/terraform.tfvars
+++ b/terraform/iaas-cluster-deployment-tf/azure/cluster/terraform.tfvars
@@ -1,0 +1,23 @@
+spectrocloud_api_key    = "j54AsdjnSP2YU9jJF1K5dVYeURWzO4qd"
+azure-cloud-account-name  = "azure-palette"
+subscription_id         = "03a79db3-46f0-4cd0-96cb-d50689f56eaa"
+resource_group          = "palette_rg"
+cluster_profile         = "tf-azure-profile"
+region                  = "eastus"
+cluster_ssh_public_key  = "azure-key"
+
+master_nodes = {
+    count            = "1"
+    instance_type    = "Standard_A2_v2"
+    disk_size_gb     = "60"
+    availability_zones = []
+    is_system_node_pool = false
+}
+
+worker_nodes = {
+    count            = "2"
+    instance_type    = "Standard_A2_v2"
+    disk_size_gb     = "60"
+    availability_zones = []
+    is_system_node_pool = false
+}

--- a/terraform/iaas-cluster-deployment-tf/azure/cluster/variables.tf
+++ b/terraform/iaas-cluster-deployment-tf/azure/cluster/variables.tf
@@ -1,0 +1,33 @@
+variable "spectrocloud_api_key" {}
+variable "subscription_id" {}
+variable "resource_group" {}
+variable "region" {}
+variable "cluster_ssh_public_key" {}
+variable "cluster_profile" {}
+
+variable "azure-cloud-account-name" {
+    type = string
+    description = "The name of your Azure account as assigned in Palette"
+}
+
+variable "master_nodes" {
+    type = object({
+        count               = string
+        instance_type       = string
+        disk_size_gb        = string
+        availability_zones  = list(string)
+        is_system_node_pool = bool
+    })
+    description = "Master nodes configuration."
+}
+
+variable "worker_nodes" {
+    type = object({
+        count           = string
+        instance_type   = string
+        disk_size_gb    = string
+        availability_zones = list(string)
+        is_system_node_pool = bool
+    })
+    description = "Worker nodes configuration."
+}

--- a/terraform/iaas-cluster-deployment-tf/azure/profile/cluster_profile.tf
+++ b/terraform/iaas-cluster-deployment-tf/azure/profile/cluster_profile.tf
@@ -1,0 +1,52 @@
+resource "spectrocloud_cluster_profile" "profile" {
+  name  = "tf-azure-profile"
+  tags  = ["ms-azure", "tutorial"]
+  cloud = "azure"
+  type  = "cluster"
+
+  pack {
+    name   = data.spectrocloud_pack.ubuntu.name
+    tag    = data.spectrocloud_pack.ubuntu.version
+    uid    = data.spectrocloud_pack.ubuntu.id
+    values = data.spectrocloud_pack.ubuntu.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.k8s.name
+    tag    = data.spectrocloud_pack.k8s.version
+    uid    = data.spectrocloud_pack.k8s.id
+    values = data.spectrocloud_pack.k8s.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.cni.name
+    tag    = data.spectrocloud_pack.cni.version
+    uid    = data.spectrocloud_pack.cni.id
+    values = data.spectrocloud_pack.cni.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.csi.name
+    tag    = data.spectrocloud_pack.csi.version
+    uid    = data.spectrocloud_pack.csi.id
+    values = data.spectrocloud_pack.csi.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.proxy.name
+    tag    = data.spectrocloud_pack.proxy.version
+    uid    = data.spectrocloud_pack.proxy.id
+    values = data.spectrocloud_pack.proxy.values
+  }
+/*
+  pack {
+    name = "hello-universe"
+    type = "manifest"
+    tag  = "1.0.0"
+    manifest {
+      name    = "hello-universe"
+      content = file("manifest.yaml")
+    }
+  }
+*/
+}

--- a/terraform/iaas-cluster-deployment-tf/azure/profile/data.tf
+++ b/terraform/iaas-cluster-deployment-tf/azure/profile/data.tf
@@ -1,0 +1,24 @@
+data "spectrocloud_pack" "csi" {
+  name    = "csi-azure"
+  version = "1.25.0"
+}
+
+data "spectrocloud_pack" "cni" {
+  name    = "cni-calico-azure"
+  version = "3.24.5"
+}
+
+data "spectrocloud_pack" "k8s" {
+  name    = "kubernetes"
+  version = "1.24.10"
+}
+
+data "spectrocloud_pack" "ubuntu" {
+  name    = "ubuntu-azure"
+  version = "20.04"
+}
+
+data "spectrocloud_pack" "proxy" {
+  name    = "spectro-proxy"
+  version = "1.2.0"
+}

--- a/terraform/iaas-cluster-deployment-tf/azure/profile/manifest.yaml
+++ b/terraform/iaas-cluster-deployment-tf/azure/profile/manifest.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-universe-service
+spec:
+  type: LoadBalancer
+  selector:
+    app: hello-universe
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-universe-deployment
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: hello-universe
+  template:
+    metadata:
+      labels:
+        app: hello-universe
+    spec:
+      containers:
+      - name: hello-universe
+        image: ghcr.io/spectrocloud/hello-universe:1.0.10
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080

--- a/terraform/iaas-cluster-deployment-tf/azure/profile/provider.tf
+++ b/terraform/iaas-cluster-deployment-tf/azure/profile/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.11.1"
+      source  = "spectrocloud/spectrocloud"
+    }
+  }
+}
+
+provider "spectrocloud" {
+  project_name = "Default"
+  api_key      = var.spectrocloud_api_key
+}

--- a/terraform/iaas-cluster-deployment-tf/azure/profile/terraform.tfvars
+++ b/terraform/iaas-cluster-deployment-tf/azure/profile/terraform.tfvars
@@ -1,0 +1,1 @@
+spectrocloud_api_key    =   "j54AsdjnSP2YU9jJF1K5dVYeURWzO4qd"

--- a/terraform/iaas-cluster-deployment-tf/azure/profile/variables.tf
+++ b/terraform/iaas-cluster-deployment-tf/azure/profile/variables.tf
@@ -1,0 +1,1 @@
+variable "spectrocloud_api_key" {}

--- a/terraform/iaas-cluster-deployment-tf/gcp/cluster/provider.tf
+++ b/terraform/iaas-cluster-deployment-tf/gcp/cluster/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.11.1"
+      source  = "spectrocloud/spectrocloud"
+    }
+  }
+}
+
+provider "spectrocloud" {
+  project_name = "Default"
+  api_key = var.spectrocloud_api_key
+}

--- a/terraform/iaas-cluster-deployment-tf/gcp/cluster/resource.tf
+++ b/terraform/iaas-cluster-deployment-tf/gcp/cluster/resource.tf
@@ -1,0 +1,40 @@
+data "spectrocloud_cloudaccount_gcp" "account" {
+  name = var.gcp-cloud-account-name
+}
+
+data "spectrocloud_cluster_profile" "profile" {
+  name = var.cluster_profile
+}
+
+resource "spectrocloud_cluster_gcp" "cluster" {
+  name             = "gcp-cluster"
+  tags             = ["gcp", "tutorial"]
+  cloud_account_id = data.spectrocloud_cloudaccount_gcp.account.id
+
+  cloud_config {
+    project = "Default"
+    region  = var.region
+  }
+
+  cluster_profile {
+    id = data.spectrocloud_cluster_profile.profile.id
+  }
+
+  machine_pool {
+    control_plane           = true
+    control_plane_as_worker = true
+    name                    = "master-pool"
+    count                   = var.master_nodes.count
+    instance_type           = var.master_nodes.instance_type
+    disk_size_gb            = var.master_nodes.disk_size_gb
+    azs                     = var.master_nodes.availability_zones
+  }
+
+  machine_pool {
+    name          = "worker-basic"
+    count         = var.worker_nodes.count
+    instance_type = var.worker_nodes.instance_type
+    disk_size_gb  = var.worker_nodes.disk_size_gb
+    azs           = var.worker_nodes.availability_zones
+  }
+}

--- a/terraform/iaas-cluster-deployment-tf/gcp/cluster/terraform.tfvars
+++ b/terraform/iaas-cluster-deployment-tf/gcp/cluster/terraform.tfvars
@@ -1,0 +1,18 @@
+spectrocloud_api_key    = "j54AsdjnSP2YU9jJF1K5dVYeURWzO4qd"
+gcp-cloud-account-name  = "myproject-379610"
+cluster_profile         = "tf-gcp-profile"
+region                  = "us-east1"
+
+master_nodes = {
+    count            = "1"
+    instance_type    = "n1-standard-2"
+    disk_size_gb     = "50"
+    availability_zones = ["us-east1-b"]
+}
+
+worker_nodes = {
+    count            = "1"
+    instance_type    = "n1-standard-2"
+    disk_size_gb     = "50"
+    availability_zones = ["us-east1-b"]
+}

--- a/terraform/iaas-cluster-deployment-tf/gcp/cluster/variables.tf
+++ b/terraform/iaas-cluster-deployment-tf/gcp/cluster/variables.tf
@@ -1,0 +1,28 @@
+variable "spectrocloud_api_key" {}
+variable "cluster_profile" {}
+variable "region" {}
+
+variable "gcp-cloud-account-name" {
+    type = string
+    description = "The name of your GCP account as assigned in Palette"
+}
+
+variable "master_nodes" {
+    type = object({
+        count           = string
+        instance_type   = string
+        disk_size_gb    = string
+        availability_zones = list(string)
+    })
+    description = "Master nodes configuration."
+}
+
+variable "worker_nodes" {
+    type = object({
+        count           = string
+        instance_type   = string
+        disk_size_gb    = string
+        availability_zones = list(string)
+    })
+    description = "Worker nodes configuration."
+}

--- a/terraform/iaas-cluster-deployment-tf/gcp/profile/cluster_profile.tf
+++ b/terraform/iaas-cluster-deployment-tf/gcp/profile/cluster_profile.tf
@@ -1,0 +1,52 @@
+resource "spectrocloud_cluster_profile" "profile" {
+  name  = "tf-gcp-profile"
+  tags  = ["gcp", "tutorial"]
+  cloud = "gcp"
+  type  = "cluster"
+
+  pack {
+    name   = data.spectrocloud_pack.ubuntu.name
+    tag    = data.spectrocloud_pack.ubuntu.version
+    uid    = data.spectrocloud_pack.ubuntu.id
+    values = data.spectrocloud_pack.ubuntu.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.k8s.name
+    tag    = data.spectrocloud_pack.k8s.version
+    uid    = data.spectrocloud_pack.k8s.id
+    values = data.spectrocloud_pack.k8s.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.cni.name
+    tag    = data.spectrocloud_pack.cni.version
+    uid    = data.spectrocloud_pack.cni.id
+    values = data.spectrocloud_pack.cni.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.csi.name
+    tag    = data.spectrocloud_pack.csi.version
+    uid    = data.spectrocloud_pack.csi.id
+    values = data.spectrocloud_pack.csi.values
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.proxy.name
+    tag    = data.spectrocloud_pack.proxy.version
+    uid    = data.spectrocloud_pack.proxy.id
+    values = data.spectrocloud_pack.proxy.values
+  }
+/*
+  pack {
+    name = "hello-universe"
+    type = "manifest"
+    tag  = "1.0.0"
+    manifest {
+      name    = "hello-universe"
+      content = file("manifest.yaml")
+    }
+  }
+*/
+}

--- a/terraform/iaas-cluster-deployment-tf/gcp/profile/data.tf
+++ b/terraform/iaas-cluster-deployment-tf/gcp/profile/data.tf
@@ -1,0 +1,24 @@
+data "spectrocloud_pack" "csi" {
+  name    = "csi-gcp-driver"
+  version = "1.7.1"
+}
+
+data "spectrocloud_pack" "cni" {
+  name    = "cni-calico"
+  version = "3.24.5"
+}
+
+data "spectrocloud_pack" "k8s" {
+  name    = "kubernetes"
+  version = "1.24.10"
+}
+
+data "spectrocloud_pack" "ubuntu" {
+  name    = "ubuntu-gcp"
+  version = "20.04"
+}
+
+data "spectrocloud_pack" "proxy" {
+  name    = "spectro-proxy"
+  version = "1.2.0"
+}

--- a/terraform/iaas-cluster-deployment-tf/gcp/profile/manifest.yaml
+++ b/terraform/iaas-cluster-deployment-tf/gcp/profile/manifest.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-universe-service
+spec:
+  type: LoadBalancer
+  selector:
+    app: hello-universe
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-universe-deployment
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: hello-universe
+  template:
+    metadata:
+      labels:
+        app: hello-universe
+    spec:
+      containers:
+      - name: hello-universe
+        image: ghcr.io/spectrocloud/hello-universe:1.0.10
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080

--- a/terraform/iaas-cluster-deployment-tf/gcp/profile/provider.tf
+++ b/terraform/iaas-cluster-deployment-tf/gcp/profile/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    spectrocloud = {
+      version = ">= 0.11.1"
+      source  = "spectrocloud/spectrocloud"
+    }
+  }
+}
+
+provider "spectrocloud" {
+  project_name = "Default"
+  api_key      = var.spectrocloud_api_key
+}

--- a/terraform/iaas-cluster-deployment-tf/gcp/profile/terraform.tfvars
+++ b/terraform/iaas-cluster-deployment-tf/gcp/profile/terraform.tfvars
@@ -1,0 +1,1 @@
+spectrocloud_api_key    =   "j54AsdjnSP2YU9jJF1K5dVYeURWzO4qd"

--- a/terraform/iaas-cluster-deployment-tf/gcp/profile/variables.tf
+++ b/terraform/iaas-cluster-deployment-tf/gcp/profile/variables.tf
@@ -1,0 +1,1 @@
+variable "spectrocloud_api_key" {}


### PR DESCRIPTION
This PR contains the terraform configuration files for cluster deployment.

The configurations files are divided into 3 folders: aws, azure, gcp. For each folder, there is the configuration to create the profile and the configuration to create the cluster.