### PR TITLE
docs: replace ngrok authtoken

### DIFF
--- a/static/defaults/ngrok.yml
+++ b/static/defaults/ngrok.yml
@@ -1,3 +1,3 @@
 # This token is intended for learning purposes, generated from https://ngrok.com/
 version: "2"
-authtoken: 2NwCDlsSFxkaX7V3ko9xXGh6e9n_PkYjDa46A1tzCW6LDsyG
+authtoken: 2PWATzqpNw94GiZ9E2Ghheh2Mal_4gYsxK4DBRVEVLEdcee8m


### PR DESCRIPTION
## Describe the Change

This PR replaces the Ngrok auth token to use the new value generated for the spectro-docs@spectrocloud.com team.

## Review Changes


🎫 Jira Ticket: [OPS-1386](https://spectrocloud.atlassian.net/browse/OPS-1386)
