### PR TITLE
fix: removed spectro-proxy from pack-tf Terraform files

### DIFF
--- a/terraform/pack-tf/README.md
+++ b/terraform/pack-tf/README.md
@@ -47,7 +47,6 @@ No modules.
 | [spectrocloud_pack.csi](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/pack) | data source |
 | [spectrocloud_pack.hellouniverse](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/pack) | data source |
 | [spectrocloud_pack.k8s](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/pack) | data source |
-| [spectrocloud_pack.spectro-proxy](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/pack) | data source |
 | [spectrocloud_pack.ubuntu](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/pack) | data source |
 | [spectrocloud_registry.hellouniverseregistry](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/registry) | data source |
 | [spectrocloud_registry.public_registry](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs/data-sources/registry) | data source |

--- a/terraform/pack-tf/data.tf
+++ b/terraform/pack-tf/data.tf
@@ -38,12 +38,6 @@ data "spectrocloud_pack" "csi" {
 ####################################
 # Add-On Layers
 ####################################
-data "spectrocloud_pack" "spectro-proxy" {
-  name         = "spectro-proxy"
-  version      = "1.4.1"
-  type         = "spectro"
-  registry_uid = data.spectrocloud_registry.public_registry.id
-}
 
 # Select the correct registry (OCI or non-OCI)
 

--- a/terraform/pack-tf/profile.tf
+++ b/terraform/pack-tf/profile.tf
@@ -41,13 +41,6 @@ resource "spectrocloud_cluster_profile" "profile" {
   ############################
   # Add-on layer
   ############################
-  # Refer to https://docs.spectrocloud.com/integrations/frp/ for more details on Spectro Proxy pack.
-  pack {
-    name   = "spectro-proxy" # Static value. Refer to the HubbleAPI collection before changing this value.
-    tag    = "1.4.x"
-    uid    = data.spectrocloud_pack.spectro-proxy.id
-    values = data.spectrocloud_pack.spectro-proxy.values
-  }
 
   # Custom add-on pack
   pack {


### PR DESCRIPTION
## Describe the Change

This PR updates the tutorial container image by removing the **spectro-proxy** pack from the Terraform files in the pack-tf folder. 

## Review Changes


🎫 [Jira Ticket]()
