### PR TITLE
fix: update provider.tf file

### DIFF
--- a/terraform/vmware-cluster-deployment-tf/provider.tf
+++ b/terraform/vmware-cluster-deployment-tf/provider.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     spectrocloud = {
-      version = ">= 0.17.4"
+      version = ">= 0.19.0-pre"
       source  = "spectrocloud/spectrocloud"
     }
 


### PR DESCRIPTION
## Describe the Change

This PR updates the [Spectro Cloud Terraform provider](https://registry.terraform.io/providers/spectrocloud/spectrocloud/latest/docs) (provider.tf file) of the PCG tutorial.