### PR TITLE
fix: address tutorial issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERS
 RUN unzip /usr/local/sbin/packer_${PACKER_VERSION}_linux_amd64.zip -d /usr/local/sbin && \
     rm -rf /usr/local/sbin/packer_${PACKER_VERSION}_linux_amd64.zip && \
     mkdir -p /home/appuser/.config/packer && mkdir /root/.spectro && \
-    chown -R appuser:appuser /home/appuser/.config/packer terraform/ packs/ edge/ CanvOS/ /var/log/ /root/.spectro/  /etc/spectro/ 
+    chown -R appuser:appuser /home/appuser/.config/packer terraform/ packs/ edge/ CanvOS/ /var/log/ /root/.spectro/ /etc/spectro/ 
 EXPOSE 5000
 
 USER appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,12 @@
 
 ARG PALETTE_VERSION
 
-FROM gcr.io/spectro-images-public/release/spectro-registry:${PALETTE_VERSION} as server
+FROM gcr.io/spectro-images-public/release/spectro-registry:${PALETTE_VERSION} AS server
 
 FROM alpine:latest
 
 LABEL org.opencontainers.image.source="https://github.com/spectrocloud/tutorials"
-LABEL org.opencontainers.image.description "An image containing all the Spectro Cloud tutorials and required tools."
+LABEL org.opencontainers.image.description="An image containing all the Spectro Cloud tutorials and required tools."
 
 ADD  terraform/ /terraform
 ADD  packs/ /packs
@@ -72,8 +72,8 @@ RUN  wget https://spectro-cli.s3.amazonaws.com/v$PALETTE_REGISTRY_CLI_VERSION/li
 ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip /usr/local/sbin/
 RUN unzip /usr/local/sbin/packer_${PACKER_VERSION}_linux_amd64.zip -d /usr/local/sbin && \
     rm -rf /usr/local/sbin/packer_${PACKER_VERSION}_linux_amd64.zip && \
-    mkdir -p /home/appuser/.config/packer && \
-    chown -R appuser:appuser /home/appuser/.config/packer
+    mkdir -p /home/appuser/.config/packer && mkdir /root/.spectro && \
+    chown -R appuser:appuser /home/appuser/.config/packer terraform/ packs/ edge/ CanvOS/ /var/log/ /root/.spectro/  /etc/spectro/ 
 EXPOSE 5000
 
 USER appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,9 @@ RUN  wget https://spectro-cli.s3.amazonaws.com/v$PALETTE_REGISTRY_CLI_VERSION/li
 
 ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip /usr/local/sbin/
 RUN unzip /usr/local/sbin/packer_${PACKER_VERSION}_linux_amd64.zip -d /usr/local/sbin && \
-    rm -rf /usr/local/sbin/packer_${PACKER_VERSION}_linux_amd64.zip
+    rm -rf /usr/local/sbin/packer_${PACKER_VERSION}_linux_amd64.zip && \
+    mkdir -p /home/appuser/.config/packer && \
+    chown -R appuser:appuser /home/appuser/.config/packer
 EXPOSE 5000
 
 USER appuser


### PR DESCRIPTION
## Describe the Change

This PR fixes permissions issues identified in the Edge tutorials when users tried to create packer files.

## Review Changes


🎫 [DOC-1302](https://spectrocloud.atlassian.net/browse/DOC-1302)


[DOC-1302]: https://spectrocloud.atlassian.net/browse/DOC-1302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ