### PR TITLE
docs: add v1.1.0 cluster profiles with Kubecost

### DIFF
--- a/terraform/cluster-templates-tf/cluster_profiles.tf
+++ b/terraform/cluster-templates-tf/cluster_profiles.tf
@@ -123,3 +123,143 @@ resource "spectrocloud_cluster_profile" "azure_profile" {
     }
   }
 }
+
+resource "spectrocloud_cluster_profile" "aws_profile_v110" {
+  count = (var.deploy-aws && var.create_new_profile_version) ? 1 : 0
+
+  name        = "tf-cluster-template-profile-aws"
+  description = "Cluster profile for the cluster templates tutorial"
+  cloud       = "aws"
+  type        = "cluster"
+  version     = "1.1.0"
+
+  pack {
+    name   = data.spectrocloud_pack.aws_ubuntu.name
+    tag    = data.spectrocloud_pack.aws_ubuntu.version
+    uid    = data.spectrocloud_pack.aws_ubuntu.id
+    values = data.spectrocloud_pack.aws_ubuntu.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_k8s.name
+    tag    = data.spectrocloud_pack.aws_k8s.version
+    uid    = data.spectrocloud_pack.aws_k8s.id
+    values = data.spectrocloud_pack.aws_k8s.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_cni.name
+    tag    = data.spectrocloud_pack.aws_cni.version
+    uid    = data.spectrocloud_pack.aws_cni.id
+    values = data.spectrocloud_pack.aws_cni.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.aws_csi.name
+    tag    = data.spectrocloud_pack.aws_csi.version
+    uid    = data.spectrocloud_pack.aws_csi.id
+    values = data.spectrocloud_pack.aws_csi.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.hellouniverse.name
+    tag    = data.spectrocloud_pack.hellouniverse.version
+    uid    = data.spectrocloud_pack.hellouniverse.id
+    values = templatefile("manifests/values-hello-universe.yaml", {
+      port = var.app_port
+    })
+    type   = "oci"
+  }
+
+  pack {
+    name = data.spectrocloud_pack.kubecost[0].name
+    tag  = data.spectrocloud_pack.kubecost[0].version
+    uid  = data.spectrocloud_pack.kubecost[0].id
+    type = "oci"
+  }
+
+  profile_variables {
+    variable {
+      name          = "app_replicas"
+      display_name  = "Hello Universe Replicas"
+      format        = "number"
+      description   = "Number of replicas for the hello-universe workload"
+      default_value = "1"
+      required      = true
+    }
+  }
+}
+
+resource "spectrocloud_cluster_profile" "azure_profile_v110" {
+  count = (var.deploy-azure && var.create_new_profile_version) ? 1 : 0
+
+  name        = "tf-cluster-template-profile-azure"
+  description = "Cluster profile for the cluster templates tutorial"
+  cloud       = "azure"
+  type        = "cluster"
+  version     = "1.1.0"
+
+  pack {
+    name   = data.spectrocloud_pack.azure_ubuntu.name
+    tag    = data.spectrocloud_pack.azure_ubuntu.version
+    uid    = data.spectrocloud_pack.azure_ubuntu.id
+    values = data.spectrocloud_pack.azure_ubuntu.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_k8s.name
+    tag    = data.spectrocloud_pack.azure_k8s.version
+    uid    = data.spectrocloud_pack.azure_k8s.id
+    values = data.spectrocloud_pack.azure_k8s.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_cni.name
+    tag    = data.spectrocloud_pack.azure_cni.version
+    uid    = data.spectrocloud_pack.azure_cni.id
+    values = data.spectrocloud_pack.azure_cni.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.azure_csi.name
+    tag    = data.spectrocloud_pack.azure_csi.version
+    uid    = data.spectrocloud_pack.azure_csi.id
+    values = data.spectrocloud_pack.azure_csi.values
+    type   = "spectro"
+  }
+
+  pack {
+    name   = data.spectrocloud_pack.hellouniverse.name
+    tag    = data.spectrocloud_pack.hellouniverse.version
+    uid    = data.spectrocloud_pack.hellouniverse.id
+    values = templatefile("manifests/values-hello-universe.yaml", {
+      port = var.app_port
+    })
+    type   = "oci"
+  }
+
+  pack {
+    name = data.spectrocloud_pack.kubecost[0].name
+    tag  = data.spectrocloud_pack.kubecost[0].version
+    uid  = data.spectrocloud_pack.kubecost[0].id
+    type = "oci"
+  }
+
+  profile_variables {
+    variable {
+      name          = "app_replicas"
+      display_name  = "Hello Universe Replicas"
+      format        = "number"
+      description   = "Number of replicas for the hello-universe workload"
+      default_value = "1"
+      required      = true
+    }
+  }
+}

--- a/terraform/cluster-templates-tf/data.tf
+++ b/terraform/cluster-templates-tf/data.tf
@@ -92,3 +92,14 @@ data "spectrocloud_pack" "hellouniverse" {
   version      = "1.3.0"
   registry_uid = data.spectrocloud_registry.community_registry.id
 }
+
+###########
+# Kubecost
+###########
+
+data "spectrocloud_pack" "kubecost" {
+  count        = var.create_new_profile_version ? 1 : 0
+  name         = "cost-analyzer"
+  version      = "1.103.3"
+  registry_uid = data.spectrocloud_registry.community_registry.id
+}

--- a/terraform/cluster-templates-tf/inputs.tf
+++ b/terraform/cluster-templates-tf/inputs.tf
@@ -21,6 +21,12 @@ variable "app_port" {
   description = "The cluster port number on which the service will listen for incoming traffic."
 }
 
+variable "create_new_profile_version" {
+  type        = bool
+  description = "Create cluster profile version 1.1.0 with Kubecost added. Set to true after the initial clusters are deployed."
+  default     = false
+}
+
 #######
 # AWS
 #######

--- a/terraform/cluster-templates-tf/terraform.tfvars
+++ b/terraform/cluster-templates-tf/terraform.tfvars
@@ -8,6 +8,8 @@ palette-project = "Default" # The name of your project in Palette.
 ##############################
 app_port = 8080 # The cluster port number on which the service will listen for incoming traffic.
 
+create_new_profile_version = false # Set to true to create cluster profile version 1.1.0 with Kubecost.
+
 ###########################
 # AWS Deployment Settings
 ############################


### PR DESCRIPTION
## Describe the Change

docs: add v1.1.0 cluster profiles with Kubecost

Add aws_profile_v110 and azure_profile_v110 Kubecost profile resources.

Add kubecost data source gated by create_new_profile_version.

Add create_new_profile_version input variable defaulting to false.

Variable defaults to false so initial clusters deploy before v1.1.0.

Refs: https://spectrocloud.atlassian.net/browse/DOC-2658

## Review Changes


🎫 [Terraform – Create new cluster profile version](https://spectrocloud.atlassian.net/browse/DOC-2658)
