### PR TITLE
docs: add profile version update step to tutorial

### DIFF
--- a/terraform/cluster-templates-tf/cluster_templates.tf
+++ b/terraform/cluster-templates-tf/cluster_templates.tf
@@ -6,7 +6,7 @@ resource "spectrocloud_cluster_config_template" "aws_template" {
   context    = "project"
 
   cluster_profile {
-    id = spectrocloud_cluster_profile.aws_profile[0].id
+    id = (var.create_new_profile_version && var.update_template_profile_version) ? spectrocloud_cluster_profile.aws_profile_v110[0].id : spectrocloud_cluster_profile.aws_profile[0].id
   }
 
   policy {
@@ -23,7 +23,7 @@ resource "spectrocloud_cluster_config_template" "azure_template" {
   context    = "project"
 
   cluster_profile {
-    id = spectrocloud_cluster_profile.azure_profile[0].id
+    id = (var.create_new_profile_version && var.update_template_profile_version) ? spectrocloud_cluster_profile.azure_profile_v110[0].id : spectrocloud_cluster_profile.azure_profile[0].id
   }
 
   policy {

--- a/terraform/cluster-templates-tf/inputs.tf
+++ b/terraform/cluster-templates-tf/inputs.tf
@@ -27,6 +27,12 @@ variable "create_new_profile_version" {
   default     = false
 }
 
+variable "update_template_profile_version" {
+  type        = bool
+  description = "Update the cluster template to reference cluster profile version 1.1.0. Requires create_new_profile_version to be true and already applied."
+  default     = false
+}
+
 #######
 # AWS
 #######

--- a/terraform/cluster-templates-tf/terraform.tfvars
+++ b/terraform/cluster-templates-tf/terraform.tfvars
@@ -10,6 +10,8 @@ app_port = 8080 # The cluster port number on which the service will listen for i
 
 create_new_profile_version = false # Set to true to create cluster profile version 1.1.0 with Kubecost.
 
+update_template_profile_version = false # Set to true after profile v1.1.0 is created to update the cluster template.
+
 ###########################
 # AWS Deployment Settings
 ############################

--- a/terraform/cluster-templates-tf/tests/aws.tftest.hcl
+++ b/terraform/cluster-templates-tf/tests/aws.tftest.hcl
@@ -61,3 +61,45 @@ run "verify_aws" {
   }
 
 }
+
+run "verify_profile_v110_planned" {
+
+  command = plan
+
+  variables {
+    create_new_profile_version      = true
+    update_template_profile_version = false
+  }
+
+  assert {
+    condition     = length(spectrocloud_cluster_profile.aws_profile_v110) == 1
+    error_message = "AWS cluster profile v1.1.0 was not planned for creation"
+  }
+
+  assert {
+    condition     = length(spectrocloud_cluster_config_template.aws_template) == 1
+    error_message = "AWS cluster template was not planned"
+  }
+
+}
+
+run "verify_template_updated_to_v110" {
+
+  command = plan
+
+  variables {
+    create_new_profile_version      = true
+    update_template_profile_version = true
+  }
+
+  assert {
+    condition     = length(spectrocloud_cluster_profile.aws_profile_v110) == 1
+    error_message = "AWS cluster profile v1.1.0 was not planned for creation"
+  }
+
+  assert {
+    condition     = length(spectrocloud_cluster_config_template.aws_template) == 1
+    error_message = "AWS cluster template was not planned for update"
+  }
+
+}

--- a/terraform/cluster-templates-tf/tests/azure.tftest.hcl
+++ b/terraform/cluster-templates-tf/tests/azure.tftest.hcl
@@ -56,3 +56,45 @@ run "verify_azure" {
   }
 
 }
+
+run "verify_profile_v110_planned" {
+
+  command = plan
+
+  variables {
+    create_new_profile_version      = true
+    update_template_profile_version = false
+  }
+
+  assert {
+    condition     = length(spectrocloud_cluster_profile.azure_profile_v110) == 1
+    error_message = "Azure cluster profile v1.1.0 was not planned for creation"
+  }
+
+  assert {
+    condition     = length(spectrocloud_cluster_config_template.azure_template) == 1
+    error_message = "Azure cluster template was not planned"
+  }
+
+}
+
+run "verify_template_updated_to_v110" {
+
+  command = plan
+
+  variables {
+    create_new_profile_version      = true
+    update_template_profile_version = true
+  }
+
+  assert {
+    condition     = length(spectrocloud_cluster_profile.azure_profile_v110) == 1
+    error_message = "Azure cluster profile v1.1.0 was not planned for creation"
+  }
+
+  assert {
+    condition     = length(spectrocloud_cluster_config_template.azure_template) == 1
+    error_message = "Azure cluster template was not planned for update"
+  }
+
+}


### PR DESCRIPTION
## Describe the Change

docs: add profile version update step to tutorial

Teach learners to migrate cluster template to new profile version.

Introduce flag that learners set after creating profile v1.1.0.

## Review Changes

🎫 [Terraform – Update template to new profile version](https://spectrocloud.atlassian.net/browse/DOC-2659)
