### PR TITLE
docs: add cluster upgrade step to tutorial

### DIFF
--- a/terraform/cluster-templates-tf/cluster_templates.tf
+++ b/terraform/cluster-templates-tf/cluster_templates.tf
@@ -13,6 +13,8 @@ resource "spectrocloud_cluster_config_template" "aws_template" {
     id   = spectrocloud_cluster_config_policy.maintenance.id
     kind = "maintenance"
   }
+
+  upgrade_now = var.upgrade_now_timestamp != "" ? var.upgrade_now_timestamp : null
 }
 
 resource "spectrocloud_cluster_config_template" "azure_template" {
@@ -30,4 +32,6 @@ resource "spectrocloud_cluster_config_template" "azure_template" {
     id   = spectrocloud_cluster_config_policy.maintenance.id
     kind = "maintenance"
   }
+
+  upgrade_now = var.upgrade_now_timestamp != "" ? var.upgrade_now_timestamp : null
 }

--- a/terraform/cluster-templates-tf/inputs.tf
+++ b/terraform/cluster-templates-tf/inputs.tf
@@ -33,6 +33,12 @@ variable "update_template_profile_version" {
   default     = false
 }
 
+variable "upgrade_now_timestamp" {
+  type        = string
+  description = "RFC3339 timestamp that triggers an immediate upgrade of all clusters launched from the template. The upgrade executes when this value changes, not at the time specified. Set to a new timestamp each time you want to fire an upgrade. Leave empty to skip."
+  default     = ""
+}
+
 #######
 # AWS
 #######

--- a/terraform/cluster-templates-tf/inputs.tf
+++ b/terraform/cluster-templates-tf/inputs.tf
@@ -35,7 +35,7 @@ variable "update_template_profile_version" {
 
 variable "upgrade_now_timestamp" {
   type        = string
-  description = "RFC3339 timestamp that triggers an immediate upgrade of all clusters launched from the template. The upgrade executes when this value changes, not at the time specified. Set to a new timestamp each time you want to fire an upgrade. Leave empty to skip."
+  description = "RFC3339 timestamp that triggers an immediate upgrade on all template clusters when changed. Set a new timestamp to re-trigger the upgrade. Leave empty to skip."
   default     = ""
 }
 

--- a/terraform/cluster-templates-tf/terraform.tfvars
+++ b/terraform/cluster-templates-tf/terraform.tfvars
@@ -12,6 +12,8 @@ create_new_profile_version = false # Set to true to create cluster profile versi
 
 update_template_profile_version = false # Set to true after profile v1.1.0 is created to update the cluster template.
 
+upgrade_now_timestamp = "" # Set to the current RFC3339 timestamp (for example, "2026-05-12T14:30:00Z") to trigger an immediate upgrade of all clusters launched from the template. Change the value each time you want to re-trigger an upgrade.
+
 ###########################
 # AWS Deployment Settings
 ############################


### PR DESCRIPTION
## Describe the Change

docs: add cluster upgrade step to tutorial

Teach users to upgrade template-launched clusters on demand.

Introduce upgrade_now_timestamp variable as trigger mechanism.

Show that new RFC3339 timestamp value triggers each subsequent upgrade.

## Review Changes


🎫 [Terraform – Upgrade clusters](https://spectrocloud.atlassian.net/browse/DOC-2660)
🎫 [Terraform – Validate upgraded clusters](https://spectrocloud.atlassian.net/browse/DOC-2661)
